### PR TITLE
AWS Kubernetes cluster with native CNIs clone from template - Brainboard pull request

### DIFF
--- a/.aws/main.tf
+++ b/.aws/main.tf
@@ -1,4 +1,4 @@
-resource "aws_vpc" "default" {
+resource "aws_vpc" "default_vpc" {
   provider = aws.us-east-1
 
   tags                             = merge(var.tags, {})
@@ -13,7 +13,7 @@ resource "aws_vpc" "default" {
 resource "aws_subnet" "snet1" {
   provider = aws.us-east-1
 
-  vpc_id                  = aws_vpc.default.id
+  vpc_id                  = aws_vpc.default_vpc.id
   tags                    = merge(var.tags, {})
   map_public_ip_on_launch = true
   cidr_block              = var.subnets[0]
@@ -23,7 +23,7 @@ resource "aws_subnet" "snet1" {
 resource "aws_subnet" "snet2" {
   provider = aws.us-east-1
 
-  vpc_id                  = aws_vpc.default.id
+  vpc_id                  = aws_vpc.default_vpc.id
   tags                    = merge(var.tags, {})
   map_public_ip_on_launch = true
   cidr_block              = var.subnets[1]
@@ -33,7 +33,7 @@ resource "aws_subnet" "snet2" {
 resource "aws_internet_gateway" "gtw" {
   provider = aws.us-east-1
 
-  vpc_id = aws_vpc.default.id
+  vpc_id = aws_vpc.default_vpc.id
 
   tags = {
     Name = "Brainboard k8s"
@@ -44,7 +44,7 @@ resource "aws_internet_gateway" "gtw" {
 resource "aws_route_table" "default" {
   provider = aws.us-east-1
 
-  vpc_id = aws_vpc.default.id
+  vpc_id = aws_vpc.default_vpc.id
   tags   = merge(var.tags, {})
 
   route {
@@ -172,7 +172,7 @@ resource "aws_iam_role_policy_attachment" "cluster-AmazonEKSVPCResourceControlle
 resource "aws_security_group" "cluster-sg" {
   provider = aws.us-east-1
 
-  vpc_id      = aws_vpc.default.id
+  vpc_id      = aws_vpc.default_vpc.id
   tags        = merge(var.tags, {})
   name        = var.sg_name
   description = "Cluster communication with worker nodes"

--- a/.aws/outputs.tf
+++ b/.aws/outputs.tf
@@ -1,0 +1,5 @@
+output "Output" {
+  sensitive = false
+  value     = aws_eks_cluster.default.id
+}
+

--- a/.aws/terraform.tfvars
+++ b/.aws/terraform.tfvars
@@ -1,2 +1,3 @@
 # All variables as it would be defined in the .tfvars file.
 
+vpn-name = "MGN-Demo-VPC"

--- a/.aws/variables.tf
+++ b/.aws/variables.tf
@@ -40,6 +40,12 @@ variable "vpc_cidr" {
   default     = "172.30.0.0/16"
 }
 
+variable "vpn-name" {
+  description = "default vpc to use"
+  type        = string
+  default     = "MGN-Demo-VPC"
+}
+
 variable "workstation-external-cidr" {
   type    = string
   default = "0.0.0.0/0"


### PR DESCRIPTION
# Architecture Schema

 ![](https://s3.us-east-2.amazonaws.com/brainboard-screenshots-prod/pr/2f80bc1b-28de-4170-8cf5-b5f1017804d9/90af81b6-04f7-461a-9338-e678847f60bd.png)

 # Description

Change the vpc name & CIDR block