### PR TITLE
AWS Kubernetes cluster with native CNIs clone from template - Brainboard pull request

### DIFF
--- a/.aws/main.tf
+++ b/.aws/main.tf
@@ -1,10 +1,19 @@
-data "aws_vpc" "selected" {
-  id = var.vpc_id
+resource "aws_vpc" "default" {
+  provider = aws.us-east-1
+
+  tags                             = merge(var.tags, {})
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  enable_classiclink_dns_support   = true
+  enable_classiclink               = true
+  cidr_block                       = var.vpc_cidr
+  assign_generated_ipv6_cidr_block = true
 }
 
 resource "aws_subnet" "snet1" {
   provider = aws.us-east-1
-  vpc_id                  = data.aws_vpc.selected.id
+
+  vpc_id                  = aws_vpc.default.id
   tags                    = merge(var.tags, {})
   map_public_ip_on_launch = true
   cidr_block              = var.subnets[0]

--- a/.aws/outputs.tf
+++ b/.aws/outputs.tf
@@ -1,0 +1,5 @@
+output "Output" {
+  sensitive = false
+  value     = aws_eks_cluster.default.id
+}
+

--- a/.aws/terraform.tfvars
+++ b/.aws/terraform.tfvars
@@ -1,2 +1,3 @@
 # All variables as it would be defined in the .tfvars file.
 
+vpn-name = "MGN-Demo-VPC"

--- a/.aws/variables.tf
+++ b/.aws/variables.tf
@@ -37,16 +37,17 @@ variable "tags" {
 variable "vpc_cidr" {
   description = "CIDR block used by the main VPC."
   type        = string
-  default     = "172.30.0.0/16"
+  default     = "10.0.0.0/16"
+}
+
+variable "vpn-name" {
+  description = "default vpc to use"
+  type        = string
+  default     = "MGN-Demo-VPC"
 }
 
 variable "workstation-external-cidr" {
   type    = string
   default = "0.0.0.0/0"
-}
-
-variable "vpc_id" {
-  type    = string
-  default = "default-vpc"
 }
 


### PR DESCRIPTION
# Architecture Schema

 ![](https://s3.us-east-2.amazonaws.com/brainboard-screenshots-prod/pr/2f80bc1b-28de-4170-8cf5-b5f1017804d9/253f4d79-013c-4d18-ad59-ef371309c706.png)

 # Description

Changes in main.tf and variables.tf